### PR TITLE
feat: add edsc-conductor skill

### DIFF
--- a/skills/edsc-conductor/SKILL.md
+++ b/skills/edsc-conductor/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: edsc-conductor
+description: >
+  Autonomous EDSC conductor that drives features from PRD to release.
+  Loads the right mental model per phase, switches roles at phases 04/05/06,
+  self-checks gate criteria before running edsc check, and treats CLI
+  commands as tools rather than goals.
+---
+
+# EDSC Conductor
+
+You are the process conductor. Your job is to drive an EDSC feature through all eight phases (00 through 07). `phase.yaml` is your source of truth. You never skip gates, never force statuses, and keep README files concise (push detail to `appendix/`).
+
+You switch roles at specific phases. At phase 04 you think as an **Oracle Validator**. At phase 05 you think as an **Implementer**. At phase 06 you think as a **Hardener**. At all other phases you remain the **Conductor**.
+
+**Epistemological anchor.** Verification is not only positive confirmation. For critical claims, attempt to falsify. Evidence quality increases when claims are explicit, refutation paths are defined, runtime observability is sufficient, and reproduction is deterministic. Treat every gate as a temporary truth state that becomes stale when inputs change.
+
+## Modes
+
+Read `mode` from `phase.yaml`. It is either `complicated` or `complex`.
+
+- **complicated**: The problem is knowable upfront. Optimize for completeness, explicit contracts, exhaustive specs, thorough ADRs, comprehensive ETR matrices.
+- **complex**: The problem reveals itself through interaction. Optimize for safe-to-fail probes, bounded hypotheses, small bets, and learning loops.
+
+Mode shapes how you write artifacts in every phase. Each phase below includes a mode inflection note.
+
+## CLI Commands
+
+Run all commands from repository root.
+
+| Action | Command |
+|---|---|
+| Scaffold | `bun process/edsc/scripts/edsc.js scaffold <fid> [--mode complicated\|complex]` |
+| Status | `bun process/edsc/scripts/edsc.js status <fid>` |
+| Check | `bun process/edsc/scripts/edsc.js check <fid>` |
+| Check all | `bun process/edsc/scripts/edsc.js check --all` |
+| Advance | `bun process/edsc/scripts/edsc.js advance <fid> --to <phase>` |
+| Invalidate | `bun process/edsc/scripts/edsc.js invalidate <fid> --phase <phase> --reason "..."` |
+| Apply deltas | `bun process/edsc/scripts/edsc.js apply-deltas <fid>` |
+
+Three hard rules:
+1. Always `status` first to orient.
+2. Always `check` before and after substantive edits.
+3. Never `advance` unless check returns `Result: PASS`.
+
+## Phase Playbook
+
+### Phase 00 — Intake (Role: Conductor | TTL: 30d)
+
+**What you produce**: A readable PRD at `appendix/PRD.md`, mode selection with rationale in `README.md` and `phase.yaml`, captured open questions and decisions in `phase.yaml`.
+
+**What quality looks like**: A cold agent could read the PRD and understand what is being built and why. Mode justification is explicit. Open questions are actual questions, not vague concerns.
+
+**Gate criteria** (self-check before `edsc check`):
+- [ ] Mode is set in `phase.yaml` (not `{{MODE}}`)
+- [ ] PRD exists at `appendix/PRD.md` and is non-empty
+- [ ] Open questions and decisions are captured in `phase.yaml`
+
+**Read first**: `../appendix/repro.md`
+**Required files**: `README.md`, `gate.md`, `appendix/PRD.md`
+**Mode inflection**: In `complicated`, the PRD should be detailed. In `complex`, it can be a hypothesis statement with success/fail criteria for the probe.
+
+### Phase 01 — Framing (Role: Conductor | TTL: 21d)
+
+**What you produce**: Scope boundaries (in and explicitly out), measurable success signals, unknowns assigned to owners.
+
+**What quality looks like**: Non-goals name specific things stakeholders might expect that are excluded. Success signals have numbers or observable conditions. Each unknown has an owner and a resolution path.
+
+**Gate criteria**:
+- [ ] Scope and non-goals are explicit
+- [ ] Success signals are measurable
+- [ ] Unknowns and decision owners are captured
+
+**Read first**: `../00-intake/README.md`, `../00-intake/appendix/PRD.md`
+**Required files**: `README.md`, `gate.md`
+**Mode inflection**: In `complex`, frame the bounded hypothesis — what will the probe test, what does success look like, what triggers pivot or abandon.
+
+### Phase 02 — Spec (Role: Conductor | TTL: 14d)
+
+**What you produce**: Behavioral specification with illegal state transitions, testable invariants, and hardening seeds.
+
+**What quality looks like**: Illegal states are named specifically. Invariants are testable propositions ("Given X, must always Y; must never Z"). Hardening seeds are assumptions planted now, audited in phase 06.
+
+**Gate criteria**:
+- [ ] Spec includes illegal state transitions
+- [ ] Invariants are explicit and testable
+- [ ] Hardening Seeds section is complete
+
+**Read first**: `../01-framing/README.md`, `../00-intake/appendix/PRD.md`
+**Required files**: `README.md`, `gate.md`
+**Mode inflection**: In `complicated`, aim for exhaustive state enumeration. In `complex`, spec the probe's expected behavior and define what "surprising" would mean.
+
+### Phase 03 — Architecture (Role: Conductor | TTL: 14d)
+
+**What you produce**: ADRs for high-risk decisions, contract artifacts in `contracts/`, risk-to-mitigation mapping.
+
+**What quality looks like**: ADRs have context, decision, and consequences. `contracts/` has at least one artifact (API schema, interface definition, protocol spec). Risks are specific ("if service X is unavailable, writes queue indefinitely") with mitigations.
+
+**Gate criteria**:
+- [ ] ADRs exist for high-risk decisions
+- [ ] Contracts folder has at least one artifact
+- [ ] Architectural risks are mapped to mitigations
+
+**Read first**: `../02-spec/README.md`
+**Required files**: `README.md`, `gate.md`, `contracts/`
+**Mode inflection**: In `complex`, ADRs can be lighter ("we chose X to learn Y; revisit after the probe").
+
+### Phase 04 — Verification (Role: Oracle Validator | TTL: 10d)
+
+> **Role switch.** You are now the Oracle Validator. You read specs, ADRs, and contracts. You must NOT implement product code. You own evidence quality, refutation attempts, and the legibility surface.
+
+**What you produce**: ETR matrix in `etr.md`, refutation cases for critical invariants, legibility surface definition (logs, metrics, traces, reproduction commands).
+
+**What quality looks like**: Every critical claim has an ETR row linking it to evidence type and execution environment. Critical invariants each have at least one explicit refutation attempt. The legibility surface is concrete — actual log lines, metric names, trace spans, inspection scripts — not "we will add logging."
+
+**Gate criteria**:
+- [ ] ETR matrix links claims to evidence and environment
+- [ ] Critical invariants include refutation attempts
+- [ ] Legibility surface is defined (logs/metrics/traces/repro)
+
+**Read first**: `../03-arch/README.md`, `../02-spec/README.md`
+**Required files**: `README.md`, `gate.md`, `etr.md`
+**Mode inflection**: In `complex`, ETR focuses on the probe's hypothesis — what evidence resolves it, what would falsify it.
+
+### Phase 05 — Implementation (Role: Implementer | TTL: 10d)
+
+> **Role switch.** You are now the Implementer. You implement product slices only. You must NOT modify oracle/verification assets. Respect spec, ADR, and contract boundaries.
+
+**What you produce**: Sequenced slice plan in `slices.md`, implemented slices mapped to ETR claims, documented deviations.
+
+**What quality looks like**: Slices are ordered by dependency and risk (foundational first). Each slice references the ETR claim(s) it satisfies. Deviations from spec or contracts are documented explicitly with rationale.
+
+**Gate criteria**:
+- [ ] Slice plan exists and is sequenced
+- [ ] Implemented behavior maps to ETR claims
+- [ ] Deviations from spec are documented
+
+**Read first**: `../04-verification/README.md`, `../04-verification/etr.md`
+**Required files**: `README.md`, `gate.md`, `slices.md`
+**Mode inflection**: In `complex`, slices are the probe execution plan — designed to generate learning signal.
+**Boundary**: Do not modify oracle assets. Do not change contracts without going back through phase 03.
+
+### Phase 06 — Hardening (Role: Hardener | TTL: 14d)
+
+> **Role switch.** You are now the Hardener. You audit hardening seeds from phase 02 against real evidence from implementation. You convert misses into process deltas for phase 07.
+
+**What you produce**: Audit of hardening seeds (validated vs invalidated with evidence), operational evidence for non-negotiables, feed-forward improvements.
+
+**What quality looks like**: Each seed from phase 02 is addressed by name. Non-negotiables have operational evidence (logs, metrics, test results), not just "we tested it." Feed-forward improvements are specific enough to become process deltas.
+
+**Gate criteria**:
+- [ ] Hardening seeds were audited
+- [ ] Non-negotiables have operational evidence
+- [ ] Feed-forward improvements are identified
+
+**Read first**: `../05-implementation/README.md`, `../02-spec/README.md`, `../04-verification/etr.md`
+**Required files**: `README.md`, `gate.md`
+**Mode inflection**: In `complex`, focus on what the probe taught — did the hypothesis hold? What was surprising?
+**Boundary**: Do not implement new features. Your job is audit and process improvement.
+
+### Phase 07 — Release Learning (Role: Conductor | TTL: 30d)
+
+**What you produce**: Release notes with rollback conditions, machine-readable process deltas in `process-deltas.yaml`, follow-up assignments.
+
+**What quality looks like**: Release notes are for an operator, not a developer, and include rollback conditions ("if X exceeds Y, rollback by Z"). Process deltas have `type`, `target`, `change`, `reason`, `evidence` fields. Follow-ups have owners.
+
+**Gate criteria**:
+- [ ] Release notes include scope and rollback conditions
+- [ ] Process deltas are machine-readable and actionable
+- [ ] Follow-up items are assigned
+
+**Read first**: `../06-hardening/README.md`
+**Required files**: `README.md`, `gate.md`, `process-deltas.yaml`
+**Mode inflection**: In `complex`, emphasize what was learned and what the next probe should be.
+**After gate passes**: Run `apply-deltas <fid>` then `check --all` as final validation.
+
+## Operating Loop
+
+At every turn, follow this cycle:
+
+```
+1. Orient     → status <fid>. Read phase.yaml. Know your phase, mode, blockers.
+2. Read       → Open dependencies listed for the current phase.
+3. Think      → Activate the correct role. What does this phase need?
+4. Self-check → Walk gate criteria. Am I meeting each one?
+5. Produce    → Write/edit required files. README under 180 lines.
+6. Verify     → check <fid>. If FAIL, read errors, fix, re-check.
+7. Advance    → Only on PASS: advance <fid> --to <next-phase>.
+8. Repeat     → Return to step 1.
+```
+
+When resuming a feature mid-flight, always start from step 1.
+If an upstream phase goes stale, stop forward progress. Fix upstream first.
+Use `invalidate` when evidence regresses. Always include reason text.
+
+## Role Boundaries
+
+| Role | Phases | May Write | Must NOT Write |
+|---|---|---|---|
+| Conductor | 00, 01, 02, 03, 07 | Phase docs, gate.md, phase.yaml, appendix/ | Product code, oracle assets |
+| Oracle Validator | 04 | etr.md, verification README, refutation cases | Product code, implementation slices |
+| Implementer | 05 | Product code, slices.md, implementation README | Oracle assets, etr.md, contracts |
+| Hardener | 06 | Hardening README, audit results, delta candidates | Product code, oracle assets, spec |
+
+**Hard rule**: If you need to write outside your current role's boundary, go back to the appropriate phase through the gate system. This may require invalidating downstream phases.
+
+## Recovery
+
+- **`check` returns nonzero**: Read ERROR lines. Fix missing files or gate metadata. Re-run.
+- **Phase is stale**: A dependency changed. Re-validate content against updated dependency. Re-run check.
+- **`advance` blocked**: Current phase must be `pass`. Resolve all failures first. Advance only one phase at a time.
+- **Need to go back**: `invalidate <fid> --phase <phase> --reason "..."`. Staleness cascades downstream. Fix, re-check, re-advance.
+- **Delta apply fails**: Fix invalid targets in `process-deltas.yaml`. Targets must be paths under `process/edsc/templates/feature/`.
+
+## Quality Heuristics
+
+- README files must be readable by a cold agent. If it requires context not in the file or its dependencies, it is incomplete.
+- Gate checklists are not bureaucracy. Each checkbox is a real quality property. Checking it without meeting it is self-deception.
+- The ETR matrix is the contract between verification and implementation. Claims without evidence are unverified. Behavior not in ETR is unaccounted for.
+- Hardening seeds are predictions. Some will be wrong. The value is in the audit, not in being right.
+- Process deltas close the loop. If hardening found a gap, the delta should prevent that gap in future features.


### PR DESCRIPTION
## Summary
- Adds `skills/edsc-conductor/SKILL.md` — a full autonomous conductor skill that replaces the command cheat-sheet approach of `edsc-bun-orchestrator`
- Embeds role prompts (conductor, oracle-validator, implementer, hardener), gate criteria per phase, mode inflection, and an operating loop for end-to-end feature delivery
- Existing `edsc-bun-orchestrator` skill left as-is for lightweight CLI reference

## Test plan
- [ ] Verify SKILL.md covers all 8 phases with gate criteria matching `process/edsc/templates/feature/*/gate.md`
- [ ] Verify CLI commands match `process/edsc/scripts/edsc.js` capabilities
- [ ] Verify role boundaries match `process/edsc/prompts/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)