### PR TITLE
fix: align gate templates with CLI gate validation

### DIFF
--- a/bin/anvil
+++ b/bin/anvil
@@ -367,12 +367,8 @@ validate_gate() {
     2-verify|4-ship)
       if ! grep -q '^Falsification:' "$gate"; then
         errors="${errors}Missing Falsification section\n"
-      elif ! grep -qE 'Tried:.*[^ ].*Observed:' "$gate" && ! (grep -q 'Tried:' "$gate" && grep -q 'Observed:' "$gate"); then
-        fals_content="$(sed -n '/^Falsification:/,/^[A-Z]/p' "$gate" | grep -c 'Tried:.*→.*Observed:' || true)"
-        empty_fals="$(sed -n '/^Falsification:/,/^[A-Z]/p' "$gate" | grep -c 'Tried: →' || true)"
-        if [ "$fals_content" -eq 0 ] || [ "$fals_content" -eq "$empty_fals" ]; then
-          errors="${errors}Falsification needs concrete Tried/Observed pairs\n"
-        fi
+      elif [ "$(has_concrete_falsification "$gate")" != "VALID" ]; then
+        errors="${errors}Falsification needs concrete Tried/Observed pairs\n"
       fi
       ;;
   esac
@@ -426,6 +422,28 @@ check_staleness() {
     fi
   done
   echo "CLEAN"
+}
+
+# Validate that falsification has non-empty Tried and Observed content
+has_concrete_falsification() {
+  gate="$1"
+
+  fals_section="$(sed -n '/^Falsification:/,/^[A-Z][a-z]*:/p' "$gate" | tail -n +2 | sed '$d' || true)"
+  if [ -z "$fals_section" ]; then
+    fals_section="$(sed -n '/^Falsification:/,$p' "$gate" | tail -n +2 || true)"
+  fi
+
+  tried_values="$(echo "$fals_section" | sed -n 's/.*Tried:[[:space:]]*//p' | sed 's/[[:space:]]*Observed:.*//' || true)"
+  observed_values="$(echo "$fals_section" | sed -n 's/.*Observed:[[:space:]]*//p' || true)"
+
+  tried_count="$(echo "$tried_values" | grep -Evc '^[[:space:]]*$' || true)"
+  observed_count="$(echo "$observed_values" | grep -Evc '^[[:space:]]*$' || true)"
+
+  if [ "$tried_count" -gt 0 ] && [ "$observed_count" -gt 0 ]; then
+    echo "VALID"
+  else
+    echo "INVALID"
+  fi
 }
 
 # Update state.yaml for a phase
@@ -622,14 +640,7 @@ cmd_lint() {
               echo "$fid $phase GATE-FALSIFICATION missing Falsification section"
               issue_count=$((issue_count + 1))
             else
-              # Must have Tried/Observed pairs with content
-              fals_section="$(sed -n '/^Falsification:/,/^[A-Z][a-z]*:/p' "$gate" | grep -v '^Falsification:' | grep -v '^[A-Z][a-z]*:' || true)"
-              if [ -z "$fals_section" ]; then
-                fals_section="$(sed -n '/^Falsification:/,$p' "$gate" | tail -n +2 || true)"
-              fi
-              has_tried="$(echo "$fals_section" | grep -c 'Tried:' || true)"
-              has_observed="$(echo "$fals_section" | grep -c 'Observed:' || true)"
-              if [ "$has_tried" -eq 0 ] || [ "$has_observed" -eq 0 ]; then
+              if [ "$(has_concrete_falsification "$gate")" != "VALID" ]; then
                 echo "$fid $phase GATE-FALSIFICATION missing Tried/Observed pairs"
                 issue_count=$((issue_count + 1))
               fi

--- a/process/anvil/templates/feature/2-verify/gate.md
+++ b/process/anvil/templates/feature/2-verify/gate.md
@@ -5,7 +5,7 @@ produces: [evidence/]
 ---
 # Gate: Verify
 
-- [ ] ETR matrix complete — every claim has evidence criteria
+- [ ] ETR matrix complete - every claim has evidence criteria
 - [ ] Acceptance tests are executable
 - [ ] Acceptance tests are RED (nothing implemented yet)
 - [ ] Each functional claim maps to a specific slice
@@ -16,4 +16,4 @@ Status: PENDING
 Rationale:
 
 Falsification:
-- Tried: → Observed:
+- Tried: -> Observed:

--- a/process/anvil/templates/feature/4-ship/gate.md
+++ b/process/anvil/templates/feature/4-ship/gate.md
@@ -16,4 +16,4 @@ Status: PENDING
 Rationale:
 
 Falsification:
-- Tried: → Observed:
+- Tried: -> Observed:


### PR DESCRIPTION
## Summary
- align `check` and `lint` falsification validation by reusing one concrete-content helper
- update verify/ship gate templates to use ASCII placeholder syntax (`Tried: -> Observed:`)
- keep fresh scaffolds structurally valid so `anvil check` reports `PENDING` instead of structural `FAIL`

## Validation
- `bin/anvil init F-ISSUE6-TEMP`
- `bin/anvil check F-ISSUE6-TEMP`
- `bin/anvil lint F-ISSUE6-TEMP`

Closes #6