### PR TITLE
chore: normalize ANVIL skill source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@ Start here, then follow links:
 
 - `docs/index.md`: full doc map.
 - `process/anvil/README.md`: how ANVIL works (5 phases, 2 roles, gating).
-- `skills/anvil/SKILL.md`: orchestrator skill for autonomous phase management.
-- `skills/anvil/prompts/`: phase-specific prompts (define, spec, verify, build, ship).
+- `.claude/skills/anvil/SKILL.md`: canonical orchestrator skill for autonomous phase management.
+- `.claude/skills/anvil/prompts/`: canonical phase-specific prompts (define, spec, verify, build, ship).
+- `skills/anvil/`: generated mirror (`bin/sync-anvil-skill sync`).
 
 When resuming a feature:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Agent Navigated Verified Implementation Lifecycle.
 
 ## Skills
 
-- **anvil**: ANVIL orchestrator — manages features through Define, Spec, Verify, Build, Ship phases. See `skills/anvil/SKILL.md` for full instructions. Invoke with `/anvil` or when the user asks to work on a feature.
+- **anvil**: ANVIL orchestrator — manages features through Define, Spec, Verify, Build, Ship phases. Canonical source is `.claude/skills/anvil/SKILL.md`. `skills/anvil/` is a generated mirror (`bin/sync-anvil-skill sync`).
 
 ## Project Conventions
 
@@ -12,4 +12,5 @@ Agent Navigated Verified Implementation Lifecycle.
 - Process definition in `process/anvil/`
 - Feature workspaces in `work/features/`
 - Templates in `process/anvil/templates/feature/`
+- Canonical ANVIL skill files live in `.claude/skills/anvil/`
 - State is derived — never manually edit `state.yaml`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Thanks for contributing.
    - `bun test`
 3. Run process checks:
    - `bun process/edsc/scripts/edsc.js check --all`
+4. Validate ANVIL skill mirror consistency:
+   - `bin/sync-anvil-skill check`
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ anvil init <feature-id>       # Scaffold a new feature from templates
 anvil status <feature-id>     # Print phase status and blockers
 anvil check <feature-id>      # Validate current gate (files, checklist, staleness)
 anvil advance <feature-id>    # Move to next phase (runs check first)
+bin/sync-anvil-skill check    # Verify skills/anvil mirror is in sync
 ```
 
 ## Repository Layout
 
 - `process/anvil/` — ANVIL process definition, templates, and README.
-- `skills/anvil/` — Orchestrator skill and phase prompts.
+- `.claude/skills/anvil/` — Canonical ANVIL skill source for Claude Code.
+- `skills/anvil/` — Generated mirror for non-Claude tooling.
 - `bin/anvil` — CLI entry point (POSIX shell script).
+- `bin/sync-anvil-skill` — Sync/check helper for skill mirror consistency.
 - `work/features/` — Generated feature workspaces.
 - `docs/` — Documentation index.
 

--- a/bin/sync-anvil-skill
+++ b/bin/sync-anvil-skill
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Sync the ANVIL skill mirror from the canonical Claude Code source.
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="$REPO_ROOT/.claude/skills/anvil"
+DST_DIR="$REPO_ROOT/skills/anvil"
+
+usage() {
+  cat <<'EOF'
+Usage: bin/sync-anvil-skill [sync|check]
+
+Commands:
+  sync   Copy .claude/skills/anvil -> skills/anvil
+  check  Exit non-zero if skills/anvil has drift from .claude/skills/anvil
+EOF
+  exit 1
+}
+
+mode="${1:-sync}"
+
+[ -d "$SRC_DIR" ] || {
+  echo "ERROR: canonical skill directory not found: $SRC_DIR" >&2
+  exit 1
+}
+
+case "$mode" in
+  sync)
+    mkdir -p "$REPO_ROOT/skills"
+    rm -rf "$DST_DIR"
+    cp -R "$SRC_DIR" "$DST_DIR"
+    echo "Synced skills/anvil from .claude/skills/anvil"
+    ;;
+  check)
+    if [ ! -d "$DST_DIR" ]; then
+      echo "ERROR: mirror directory missing: $DST_DIR" >&2
+      echo "Run: bin/sync-anvil-skill sync" >&2
+      exit 1
+    fi
+
+    if diff -ru "$SRC_DIR" "$DST_DIR" >/dev/null; then
+      echo "OK: skills/anvil is in sync with .claude/skills/anvil"
+    else
+      echo "ERROR: skills/anvil drifted from .claude/skills/anvil" >&2
+      echo "Run: bin/sync-anvil-skill sync" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,9 @@ This repository uses docs as a system of record.
 ## Process
 
 - `process/anvil/README.md`: ANVIL overview — 5 phases, 2 roles, gating mechanics.
-- `skills/anvil/SKILL.md`: orchestrator skill for autonomous phase management.
-- `skills/anvil/prompts/`: phase-specific prompts (define, spec, verify, build, ship).
+- `.claude/skills/anvil/SKILL.md`: canonical orchestrator skill for autonomous phase management.
+- `.claude/skills/anvil/prompts/`: canonical phase-specific prompts (define, spec, verify, build, ship).
+- `skills/anvil/`: generated mirror for non-Claude tooling (`bin/sync-anvil-skill sync`).
 
 ## CLI
 

--- a/skills/anvil/SKILL.md
+++ b/skills/anvil/SKILL.md
@@ -1,84 +1,133 @@
+---
+name: anvil
+description: ANVIL orchestrator — manages features through Define, Spec, Verify, Build, Ship phases. Use when the user wants to work on a feature, init a feature, or check feature status.
+---
+
 # ANVIL Orchestrator
 
-**Agent Navigated Verified Implementation Lifecycle**
+You manage feature lifecycles through five phases: Define, Spec, Verify, Build, Ship.
 
-You are the ANVIL orchestrator. You manage the lifecycle of features through five phases: Define, Spec, Verify, Build, Ship.
+## Startup Protocol (non-negotiable)
 
-## Invocation
-
-The user invokes you by running `anvil` or asking to work on a feature. Auto-detect what to do based on state.
-
-## Startup Protocol
-
-Every session begins with:
-
-1. **Mechanical check**: Run `anvil check <id>` for the active feature. Non-negotiable.
-2. **If not CLEAN**: Address the issue before proceeding.
-   - STALE → re-verify the affected gate
-   - DIRTY → commit or discard
-   - FAIL → fix missing files or unchecked items
-3. **Executable evidence check**: Run all graduated acceptance tests for passed phases. If any fail, mark the corresponding gate STALE.
-4. **External context check**: Ask the user ONE question: *"Has anything changed outside this repo since the last session — requirements, business context, external contracts?"*
-5. **If CLEAN + tests pass + no external changes**: Proceed from current phase.
+1. Run `bash bin/anvil list` to see all features.
+2. Run `bash bin/anvil check <id>` for the active feature.
+3. If not CLEAN: fix before proceeding (STALE → re-verify, DIRTY → commit, FAIL → fix).
+4. Ask the user: *"Has anything changed outside this repo since the last session?"*
+5. If CLEAN + no changes: proceed from effective phase.
 
 ## Phase Detection
 
-Read `state.yaml` for the feature. The **effective phase** is the LOWEST phase that is not CLEAN:
-- Run `anvil status <id>` to see the full picture
-- Work on the effective phase, not necessarily the nominal phase
+Effective phase = lowest phase that is not CLEAN. Run `bash bin/anvil status <id>`.
+
+## Phase Execution
+
+Read the phase prompt from `.claude/skills/anvil/prompts/<phase>.md` before starting work.
+
+### Direct phases (orchestrator does the work)
+
+**Define** — Interview the user with `AskUserQuestion` (up to 4 questions at a time). Synthesize into `0-define/brief.md`. See `prompts/define.md`.
+
+**Spec** — Light interview on edge cases, then write `1-spec/spec.md` and `1-spec/contracts/`. See `prompts/spec.md`.
+
+**Ship** — Audit hardening seeds, generate review bundle, handoff. See `prompts/ship.md`.
+
+### Subagent phases (orchestrator MUST delegate)
+
+**Verify** — You MUST spawn a subagent. Do NOT write acceptance tests yourself.
+
+```
+Use the Agent tool with:
+  subagent_type: "general-purpose"
+  description: "Architect: Verify phase"
+  prompt: |
+    You are an ARCHITECT working on the Verify phase for feature <ID>.
+    Your job is to TRY TO BREAK the spec, not confirm it.
+
+    Read these files:
+    - work/features/<ID>/1-spec/spec.md
+    - work/features/<ID>/1-spec/contracts/
+
+    Then read the full verify prompt:
+    - .claude/skills/anvil/prompts/verify.md
+
+    Write executable acceptance tests in:
+    - work/features/<ID>/2-verify/evidence/
+
+    Complete the gate checklist in:
+    - work/features/<ID>/2-verify/gate.md
+
+    Run the tests to confirm they are RED (nothing implemented yet).
+    Run `bash bin/anvil check <ID>` at the end.
+```
+
+After the subagent completes, verify: tests exist, tests are RED, gate is filled.
+
+**Build** — You MUST spawn a subagent per slice in a worktree. Do NOT write product code yourself.
+
+```
+Use the Agent tool with:
+  subagent_type: "general-purpose"
+  isolation: "worktree"
+  description: "Builder: slice N"
+  prompt: |
+    You are a BUILDER working on slice <N> of feature <ID>.
+
+    Read these files:
+    - work/features/<ID>/3-build/slices.md (your slice)
+    - work/features/<ID>/2-verify/evidence/ (acceptance tests)
+    - work/features/<ID>/1-spec/contracts/ (interface contract)
+
+    Then read the full build prompt:
+    - .claude/skills/anvil/prompts/build.md
+
+    TDD cycle:
+    1. Run acceptance tests → confirm RED
+    2. Implement until GREEN
+    3. Write unit tests for your implementation
+    4. Commit your work
+
+    Constraints:
+    - You may ONLY modify: bin/**, src/**, test/**, work/features/<ID>/3-build/**
+    - Do NOT modify acceptance test assertions
+    - If a test is wrong, tag BLOCKED in slices.md and STOP
+    - Do NOT touch state.yaml, gate.md, or spec/verify files
+```
+
+After the Builder subagent completes:
+1. Review `git diff --stat` from the worktree
+2. Check no spec/verify/gate files were modified
+3. Run acceptance tests to confirm GREEN
+4. If all slices done: complete `3-build/gate.md` and run `bash bin/anvil advance <ID>`
 
 ## Role Enforcement
 
 | Role | Phases | May write | Must NOT write |
 |------|--------|-----------|----------------|
-| **Architect** | Define, Spec, Verify, Ship | Phase docs, gates, specs, evidence, acceptance tests | Product code |
-| **Builder** | Build | Product code, unit/integration tests, slice docs | Specs, evidence criteria, gates, acceptance tests |
+| **Architect** | Define, Spec, Verify, Ship | Phase docs, gates, specs, evidence, tests | Product code |
+| **Builder** | Build | Product code, unit tests, slice docs | Specs, gates, evidence, acceptance tests |
 
-### Builder Isolation
-- Builder subagents work in **git worktrees** (isolated copies)
-- After completion, review `git diff --stat` from the worktree
-- Changes outside allowed paths are **flagged for review** (not auto-rejected)
+**The orchestrator (you) is the Architect for direct phases. You NEVER write product code.**
 
-## Phase Prompts
+## Gate Format
 
-Load the phase-specific prompt from `skills/anvil/prompts/`:
-- `define.md` — Interview protocol + brief synthesis
-- `spec.md` — Spec writing + hardening seeds
-- `verify.md` — ETR matrix + refutation strategy
-- `build.md` — Slice execution + TDD + subagent spawning
-- `ship.md` — Audit + review bundle + process improvements
+Rationale content must be on the line AFTER `Rationale:` (not on the same line) and must reference a file path or backtick-quoted term.
 
-Reusable protocols:
-- `interview.md` — Structured interview protocol (used by Define + Spec)
-- `handoff.md` — Review handoff protocol (Codex, human, etc.)
+```
+Status: PASS
+Rationale:
+  `spec.md` covers all behavioral requirements...
+```
 
-## Phase Transitions
+## CLI
 
-To advance between phases:
-1. Complete all work for the current phase
-2. Fill in the gate checklist (all items checked)
-3. Set gate Status to PASS with a non-empty Rationale
-4. Run `anvil advance <id>` — it validates the gate and advances
-
-## Escalation Protocol
-
-When a Builder hits an acceptance test that doesn't match reality:
-1. Builder tags the slice as `BLOCKED: <reason> → <test-file-ref>` in `slices.md`
-2. Builder stops work on that slice (may continue other slices)
-3. Orchestrator spawns an **Architect subagent** to fix the acceptance test
-4. Architect fixes the test in `2-verify/evidence/`
-5. After fix, re-run `anvil check` — Build gate becomes STALE → Builder re-verifies
-
-## Subagent Strategy
-
-| Phase | Approach | Why |
-|-------|----------|-----|
-| Define | Direct conversation | Interview needs back-and-forth |
-| Spec | Direct conversation | Spec writing benefits from Q&A |
-| Verify | Spawn subagent (Architect) | Fresh context prevents spec-writing bias |
-| Build | Spawn subagent per slice (Builder) | Fresh agent per task, TDD per slice |
-| Ship | Direct conversation | Audit + retrospective need user |
+```sh
+bash bin/anvil init <id>       # Scaffold feature
+bash bin/anvil list             # List all features
+bash bin/anvil status <id>     # Phase status + blockers
+bash bin/anvil check <id>      # Validate gate
+bash bin/anvil advance <id>    # Move to next phase
+```
 
 ## State Management
 
-`state.yaml` is a **derived cache** — NEVER manually edit it. Source of truth is gate.md content + git history. Only `anvil check` and `anvil advance` write to it.
+`state.yaml` is derived — NEVER edit manually. Only `anvil check` and `anvil advance` write to it.


### PR DESCRIPTION
## Summary
- declare `.claude/skills/anvil` as the canonical source of truth in repo docs
- add `bin/sync-anvil-skill` with deterministic `sync` and `check` modes
- regenerate `skills/anvil` mirror from canonical source (fixes drift in `skills/anvil/SKILL.md`)

## Validation
- `bin/sync-anvil-skill sync`
- `bin/sync-anvil-skill check`

Closes #7