### PR TITLE
feat: add Claude hooks for deterministic Anvil guardrails

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,25 @@
+# Claude Hooks for ANVIL Guardrails
+
+This repository uses deterministic Claude Code hooks to enforce high-confidence safety rules.
+
+## Enabled Guardrails
+
+1. `block_destructive_bash.py` (PreToolUse, matcher: `Bash`)
+   - Blocks obviously destructive commands (`rm -rf`, `git reset --hard`, `git clean -fd`, etc.).
+
+2. `block_illegal_path_edits.py` (PreToolUse, matcher: `Edit|Write|MultiEdit`)
+   - Blocks edits outside the repo root.
+   - Blocks edits under `.git/`.
+   - Blocks edits to `.claude/settings.local.json`.
+   - Blocks edits inside `.claude/worktrees/`.
+   - Blocks manual edits to derived `work/features/<id>/state.yaml`.
+
+3. `run_anvil_lint_async.py` (PostToolUse async, matcher: `Edit|Write|MultiEdit`)
+   - Runs `bin/anvil lint` asynchronously after writes.
+   - Emits a system message only on failure.
+
+## Migration / Rollout Notes
+
+- Start with the high-confidence destructive Bash denylist.
+- Expand/adjust path rules based on observed false positives.
+- Keep async validation lightweight to avoid noisy feedback loops.

--- a/.claude/hooks/block_destructive_bash.py
+++ b/.claude/hooks/block_destructive_bash.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block obviously destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+BLOCKED_SUBSTRINGS = (
+    "rm -rf",
+    "rm -fr",
+    "git reset --hard",
+    "git checkout --",
+    "git clean -fd",
+    "git clean -xdf",
+    "del /f /s /q",
+    "remove-item -recurse -force",
+)
+
+
+def emit_deny(reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(payload))
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    normalized = command.lower()
+
+    for candidate in BLOCKED_SUBSTRINGS:
+        if candidate in normalized:
+            preview = command.strip().replace("\n", " ")
+            preview = preview[:160]
+            emit_deny(f"Blocked destructive Bash command pattern: {preview}")
+            return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/block_illegal_path_edits.py
+++ b/.claude/hooks/block_illegal_path_edits.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block illegal path edits for ANVIL constraints."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+DERIVED_STATE_RE = re.compile(r"^work/features/[^/]+/state\.yaml$")
+
+
+def emit_deny(reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(payload))
+
+
+def normalize_path(project_root: Path, raw_path: str) -> Path:
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    return candidate.resolve(strict=False)
+
+
+def path_outside_project(project_root: Path, target: Path) -> bool:
+    try:
+        target.relative_to(project_root)
+        return False
+    except ValueError:
+        return True
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    file_path = str(tool_input.get("file_path") or "").strip()
+    if not file_path:
+        return 0
+
+    project_root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()).resolve(strict=False)
+    target = normalize_path(project_root, file_path)
+
+    if path_outside_project(project_root, target):
+        emit_deny(f"Blocked edit outside repository root: {file_path}")
+        return 0
+
+    rel = target.relative_to(project_root).as_posix()
+
+    if rel == ".git" or rel.startswith(".git/"):
+        emit_deny("Blocked edits under .git/")
+        return 0
+
+    if rel == ".claude/settings.local.json":
+        emit_deny("Blocked edits to local-only Claude settings (.claude/settings.local.json)")
+        return 0
+
+    if rel.startswith(".claude/worktrees/"):
+        emit_deny("Blocked edits inside .claude/worktrees/")
+        return 0
+
+    if DERIVED_STATE_RE.match(rel):
+        emit_deny("Blocked manual edits to derived state cache: work/features/<id>/state.yaml")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/run_anvil_lint_async.py
+++ b/.claude/hooks/run_anvil_lint_async.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""PostToolUse async hook: run lightweight ANVIL validation after writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def is_unavailable_error(return_code: int, output: str) -> bool:
+    lowered = output.lower()
+    return (
+        return_code in (126, 127)
+        or "command not found" in lowered
+        or "no such file or directory" in lowered
+        or "execvpe" in lowered
+    )
+
+
+def run_lint(project_root: Path) -> tuple[int, str]:
+    anvil = project_root / "bin" / "anvil"
+
+    candidates: list[list[str]] = []
+    if anvil.exists():
+        candidates.append([str(anvil), "lint"])
+
+    for shell in ("sh", "bash"):
+        if shutil.which(shell):
+            candidates.append([shell, str(anvil), "lint"])
+
+    if os.name == "nt":
+        program_files = os.environ.get("ProgramFiles")
+        if program_files:
+            git_bash = Path(program_files) / "Git" / "bin" / "bash.exe"
+            if git_bash.exists():
+                candidates.append([str(git_bash), str(anvil), "lint"])
+
+    last_output = ""
+    for cmd in candidates:
+        try:
+            completed = subprocess.run(
+                cmd,
+                cwd=str(project_root),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            continue
+
+        combined_output = (completed.stdout + completed.stderr).strip()
+        if completed.returncode == 0:
+            return 0, ""
+
+        if is_unavailable_error(completed.returncode, combined_output):
+            last_output = combined_output
+            continue
+
+        return completed.returncode, combined_output
+
+    # If no runnable shell exists in this environment, skip quietly.
+    return 0, last_output
+
+
+def emit_message(message: str) -> None:
+    print(json.dumps({"systemMessage": message}))
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    file_path = str(tool_input.get("file_path") or "").strip()
+
+    project_root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()).resolve(strict=False)
+    return_code, output = run_lint(project_root)
+    if return_code == 0:
+        return 0
+
+    excerpt = " | ".join(line.strip() for line in output.splitlines() if line.strip())
+    excerpt = excerpt[:600]
+
+    if file_path:
+        emit_message(f"anvil lint failed after editing {file_path}. {excerpt}")
+    else:
+        emit_message(f"anvil lint failed after a write operation. {excerpt}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/block_destructive_bash.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/block_illegal_path_edits.py\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/run_anvil_lint_async.py\"",
+            "async": true,
+            "timeout": 180
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,4 +12,5 @@ Agent Navigated Verified Implementation Lifecycle.
 - Process definition in `process/anvil/`
 - Feature workspaces in `work/features/`
 - Templates in `process/anvil/templates/feature/`
+- Deterministic Claude hooks configured in `.claude/settings.json`
 - State is derived — never manually edit `state.yaml`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Anvil is a simplified agentic SDLC that fuses rigorous phase-gating with practic
 It includes:
 - A zero-dependency POSIX shell CLI for scaffolding, checking, and advancing features.
 - Mechanical gate validation (required files, checklists, git-based staleness detection).
+- Deterministic Claude Code hooks for safety and post-write validation.
 - Feature templates and phase prompts for structured execution.
 - Two roles (Architect + Builder) with transparent diff-based enforcement.
 - Falsification-first verification with executable acceptance tests.
@@ -44,6 +45,8 @@ anvil advance <feature-id>    # Move to next phase (runs check first)
 
 - `process/anvil/` — ANVIL process definition, templates, and README.
 - `skills/anvil/` — Orchestrator skill and phase prompts.
+- `.claude/hooks/` — Deterministic Claude guardrails and async lint hook.
+- `.claude/settings.json` — Hook configuration.
 - `bin/anvil` — CLI entry point (POSIX shell script).
 - `work/features/` — Generated feature workspaces.
 - `docs/` — Documentation index.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ This repository uses docs as a system of record.
 - `process/anvil/README.md`: ANVIL overview — 5 phases, 2 roles, gating mechanics.
 - `skills/anvil/SKILL.md`: orchestrator skill for autonomous phase management.
 - `skills/anvil/prompts/`: phase-specific prompts (define, spec, verify, build, ship).
+- `.claude/hooks/README.md`: deterministic Claude hook guardrails and async validation.
 
 ## CLI
 


### PR DESCRIPTION
## Summary
- add deterministic Claude hook config in `.claude/settings.json`
- block obviously destructive Bash commands (`rm -rf`, `git reset --hard`, `git clean -fd`, etc.)
- block illegal path edits (outside repo, `.git/`, `.claude/worktrees/`, `.claude/settings.local.json`, and derived `work/features/<id>/state.yaml`)
- add async post-write `anvil lint` hook with failure-only messaging
- document rollout and guardrail intent in `.claude/hooks/README.md`

## Validation
- `echo '{"tool_input":{"command":"rm -rf /tmp/foo"}}' | python .claude/hooks/block_destructive_bash.py`
- `echo '{"tool_input":{"file_path":"work/features/F-1/state.yaml"}}' | python .claude/hooks/block_illegal_path_edits.py`
- `python -m json.tool .claude/settings.json`
- `echo '{"tool_input":{"file_path":"README.md"}}' | python .claude/hooks/run_anvil_lint_async.py`

Closes #8
