### PR TITLE
fix: rationale parser and test performance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Agent Navigated Verified Implementation Lifecycle.
 
 ## Project Conventions
 
+- Anvil is consumed by LLM agents, not humans — optimize all output for context density and token efficiency
 - CLI lives at `bin/anvil` (POSIX shell)
 - Process definition in `process/anvil/`
 - Feature workspaces in `work/features/`

--- a/bin/anvil
+++ b/bin/anvil
@@ -252,7 +252,7 @@ cmd_advance() {
 cmd_list() {
   # Handle missing or empty features directory
   if [ ! -d "$FEATURES_DIR" ]; then
-    exit 0
+    return 0
   fi
 
   for dir in "$FEATURES_DIR"/*/; do
@@ -335,11 +335,17 @@ validate_gate() {
   fi
 
   # 3. Check Rationale is non-empty and contains a reference
-  rationale="$(sed -n '/^Rationale:/,/^[A-Z]/p' "$gate" | grep -v '^Rationale:' | grep -v '^[A-Z]' | tr -d '[:space:]' || true)"
+  # Support both inline (Rationale: text) and next-line (Rationale:\n  text) formats
+  rationale_inline="$(grep '^Rationale:' "$gate" | sed 's/^Rationale: *//' | tr -d '[:space:]' || true)"
+  rationale_block="$(sed -n '/^Rationale:/,/^[A-Z]/p' "$gate" | grep -v '^Rationale:' | grep -v '^[A-Z]' | tr -d '[:space:]' || true)"
+  rationale="${rationale_inline}${rationale_block}"
   if [ -z "$rationale" ]; then
     errors="${errors}Rationale is empty\n"
-  elif ! grep -q 'Rationale:' "$gate" || ! sed -n '/^Rationale:/,/^$/p' "$gate" | grep -qE '`[^`]+`|[a-zA-Z0-9/_.-]+\.[a-zA-Z]'; then
-    errors="${errors}Rationale must reference a file path or backtick-quoted term\n"
+  else
+    rationale_full="$(sed -n '/^Rationale:/,/^[A-Z]/p' "$gate" || true)"
+    if ! echo "$rationale_full" | grep -qE '`[^`]+`|[a-zA-Z0-9/_.-]+\.[a-zA-Z]'; then
+      errors="${errors}Rationale must reference a file path or backtick-quoted term\n"
+    fi
   fi
 
   # 4. Check produces files exist
@@ -456,14 +462,14 @@ cmd_lint() {
     case "$id" in
       *..*)
         echo "ERROR: invalid feature ID (directory traversal rejected)" >&2
-        exit 1
+        return 1
         ;;
     esac
   fi
 
   # Handle missing FEATURES_DIR
   if [ ! -d "$FEATURES_DIR" ]; then
-    exit 0
+    return 0
   fi
 
   # Build list of features to lint
@@ -471,7 +477,7 @@ cmd_lint() {
     fdir="$(feature_dir "$id")"
     if [ ! -d "$fdir" ]; then
       echo "ERROR: Feature $id not found at $fdir" >&2
-      exit 1
+      return 1
     fi
     feature_list="$id"
   else
@@ -667,21 +673,24 @@ cmd_lint() {
   # Actually, we've been printing directly to stdout, so we need a different approach
   # Let's exit based on issue_count
   if [ "$issue_count" -gt 0 ]; then
-    exit 1
+    return 1
   fi
-  exit 0
+  return 0
 }
 
 # --- main ---
-[ $# -lt 1 ] && usage
-cmd="$1"; shift
+# Guard: skip dispatch when sourced (allows tests to call functions directly)
+if [ "${ANVIL_SOURCED:-0}" != "1" ]; then
+  [ $# -lt 1 ] && usage
+  cmd="$1"; shift
 
-case "$cmd" in
-  init)    cmd_init "$@" ;;
-  status)  cmd_status "$@" ;;
-  check)   cmd_check "$@" ;;
-  advance) cmd_advance "$@" ;;
-  list)    cmd_list "$@" ;;
-  lint)    cmd_lint "$@" ;;
-  *)       usage ;;
-esac
+  case "$cmd" in
+    init)    cmd_init "$@" ;;
+    status)  cmd_status "$@" ;;
+    check)   cmd_check "$@" ;;
+    advance) cmd_advance "$@" ;;
+    list)    cmd_list "$@" ;;
+    lint)    cmd_lint "$@" ;;
+    *)       usage ;;
+  esac
+fi

--- a/work/features/F-2026-02-dashboard/2-verify/evidence/run-tests.sh
+++ b/work/features/F-2026-02-dashboard/2-verify/evidence/run-tests.sh
@@ -1,15 +1,31 @@
 #!/bin/sh
 # ETR acceptance test runner for F-2026-02-dashboard (anvil list)
-# All tests should be RED before Build phase.
+# Optimized: sourced functions (no fork per test).
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../../../.." && pwd)"
 ANVIL="$REPO_ROOT/bin/anvil"
 FEATURES_DIR="$REPO_ROOT/work/features"
+export FEATURES_DIR
 
 pass=0
 fail=0
 total=0
+
+# Source anvil functions once
+ANVIL_SOURCED=1 . "$ANVIL"
+
+# run_list — calls cmd_list directly, captures stdout, stderr, exit code
+# Sets: _stdout, _stderr, _exit
+run_list() {
+  _stderr_file="$(mktemp)"
+  set +e
+  _stdout="$(cmd_list 2>"$_stderr_file")"
+  _exit=$?
+  set -e
+  _stderr="$(cat "$_stderr_file")"
+  rm -f "$_stderr_file"
+}
 
 assert_eq() {
   total=$((total + 1))
@@ -21,18 +37,6 @@ assert_eq() {
     echo "  FAIL: $label"
     echo "    expected: $(echo "$expected" | head -3)"
     echo "    actual:   $(echo "$actual" | head -3)"
-    fail=$((fail + 1))
-  fi
-}
-
-assert_exit_zero() {
-  total=$((total + 1))
-  label="$1"; shift
-  if "$@" >/dev/null 2>&1; then
-    echo "  PASS: $label"
-    pass=$((pass + 1))
-  else
-    echo "  FAIL: $label (exit non-zero)"
     fail=$((fail + 1))
   fi
 }
@@ -63,40 +67,17 @@ assert_not_contains() {
   fi
 }
 
-assert_line_count() {
-  total=$((total + 1))
-  label="$1"; expected="$2"; actual="$3"
-  count="$(echo "$actual" | grep -c '.' || true)"
-  if [ "$count" -eq "$expected" ]; then
-    echo "  PASS: $label"
-    pass=$((pass + 1))
-  else
-    echo "  FAIL: $label (expected $expected lines, got $count)"
-    fail=$((fail + 1))
-  fi
-}
-
-# --- Setup: create temp features for testing ---
-setup_temp_features() {
-  TMPDIR_FEATURES="$FEATURES_DIR/_test_tmp_$$"
-  mkdir -p "$TMPDIR_FEATURES"
-}
-
-teardown_temp_features() {
-  [ -d "$TMPDIR_FEATURES" ] && rm -rf "$TMPDIR_FEATURES"
-}
-
 # ============================================================
 echo "=== ETR-1: anvil list is a recognized command (BR-8) ==="
-output="$(bash "$ANVIL" list 2>&1 || true)"
-assert_not_contains "ETR-1: list is not rejected as unknown" "Usage:" "$output"
+run_list
+assert_not_contains "ETR-1: list is not rejected as unknown" "Usage:" "$_stdout$_stderr"
 
 # ============================================================
 echo "=== ETR-2: one line per feature (BR-1, INV-1) ==="
-output="$(bash "$ANVIL" list 2>/dev/null || true)"
+run_list
 feature_count="$(ls -d "$FEATURES_DIR"/F-* 2>/dev/null | wc -l | tr -d ' ')"
 if [ "$feature_count" -gt 0 ]; then
-  line_count="$(echo "$output" | grep -c '.' || true)"
+  line_count="$(echo "$_stdout" | grep -c '.' || true)"
   assert_eq "ETR-2: line count matches feature count" "$feature_count" "$line_count"
 else
   echo "  SKIP: no features present"
@@ -104,10 +85,9 @@ fi
 
 # ============================================================
 echo "=== ETR-3: output format is '<id> <phase> <status>' (BR-2) ==="
-output="$(bash "$ANVIL" list 2>/dev/null || true)"
-if [ -n "$output" ]; then
-  # Every line must have exactly 3 space-separated fields
-  bad_lines="$(echo "$output" | awk 'NF != 3 { print }' || true)"
+run_list
+if [ -n "$_stdout" ]; then
+  bad_lines="$(echo "$_stdout" | awk 'NF != 3 { print }' || true)"
   assert_eq "ETR-3: all lines have 3 fields" "" "$bad_lines"
 else
   echo "  SKIP: no output to check"
@@ -115,13 +95,12 @@ fi
 
 # ============================================================
 echo "=== ETR-4: effective phase matches anvil status (BR-3, INV-4) ==="
-output="$(bash "$ANVIL" list 2>/dev/null || true)"
-if [ -n "$output" ]; then
-  first_id="$(echo "$output" | head -1 | awk '{print $1}')"
-  list_phase="$(echo "$output" | head -1 | awk '{print $2}')"
+run_list
+if [ -n "$_stdout" ]; then
+  first_id="$(echo "$_stdout" | head -1 | awk '{print $1}')"
+  list_phase="$(echo "$_stdout" | head -1 | awk '{print $2}')"
   status_phase="$(bash "$ANVIL" status "$first_id" 2>/dev/null | grep 'Effective phase:' | awk '{print $3}' || true)"
   if [ -z "$status_phase" ]; then
-    # All clean case
     status_phase="4-ship"
   fi
   assert_eq "ETR-4: list phase matches status effective phase" "$status_phase" "$list_phase"
@@ -131,18 +110,14 @@ fi
 
 # ============================================================
 echo "=== ETR-5: empty features dir produces no output (BR-7, ERR-3) ==="
-# Remove all F-* dirs temporarily, test, then restore
-# Use a simpler approach: check that list exits 0 when only non-feature dirs exist
-# We verify the zero-feature invariant by ensuring the command doesn't crash
-assert_exit_zero "ETR-5: list exits 0 even with current features" bash "$ANVIL" list
+assert_eq "ETR-5: list exits 0" "0" "$_exit"
 
 # ============================================================
 echo "=== ETR-6: read-only — no files modified (IT-1, IT-2, IT-3) ==="
 if [ -d "$FEATURES_DIR" ] && ls "$FEATURES_DIR"/F-* >/dev/null 2>&1; then
-  # Snapshot state.yaml mtimes
-  before="$(find "$FEATURES_DIR" -name state.yaml -exec stat -c '%Y %n' {} + 2>/dev/null || find "$FEATURES_DIR" -name state.yaml -exec stat -f '%m %N' {} + 2>/dev/null || true)"
-  bash "$ANVIL" list >/dev/null 2>&1 || true
-  after="$(find "$FEATURES_DIR" -name state.yaml -exec stat -c '%Y %n' {} + 2>/dev/null || find "$FEATURES_DIR" -name state.yaml -exec stat -f '%m %N' {} + 2>/dev/null || true)"
+  before="$(find "$FEATURES_DIR" -name state.yaml -exec ls -l --time-style=+%s {} + 2>/dev/null || find "$FEATURES_DIR" -name state.yaml -exec stat -f '%m %N' {} + 2>/dev/null || true)"
+  run_list
+  after="$(find "$FEATURES_DIR" -name state.yaml -exec ls -l --time-style=+%s {} + 2>/dev/null || find "$FEATURES_DIR" -name state.yaml -exec stat -f '%m %N' {} + 2>/dev/null || true)"
   assert_eq "ETR-6: state.yaml unchanged after list" "$before" "$after"
 else
   echo "  SKIP: no features to check"
@@ -150,12 +125,10 @@ fi
 
 # ============================================================
 echo "=== ETR-7: malformed feature warns on stderr (ERR-1, INV-3) ==="
-# Create a directory without state.yaml
 mkdir -p "$FEATURES_DIR/F-test-broken-$$"
-stderr_output="$(bash "$ANVIL" list 2>&1 1>/dev/null || true)"
-stdout_output="$(bash "$ANVIL" list 2>/dev/null || true)"
-assert_contains "ETR-7a: stderr warns about broken feature" "warning" "$stderr_output"
-assert_not_contains "ETR-7b: warning not on stdout" "warning" "$stdout_output"
+run_list
+assert_contains "ETR-7a: stderr warns about broken feature" "warning" "$_stderr"
+assert_not_contains "ETR-7b: warning not on stdout" "warning" "$_stdout"
 rm -rf "$FEATURES_DIR/F-test-broken-$$"
 
 # ============================================================

--- a/work/features/F-2026-02-lint/2-verify/evidence/run-tests.sh
+++ b/work/features/F-2026-02-lint/2-verify/evidence/run-tests.sh
@@ -1,16 +1,33 @@
 #!/bin/sh
 # ETR acceptance test runner for F-2026-02-lint (anvil lint)
-# All tests should be RED before Build phase.
+# Optimized: batched fixtures + sourced functions (no fork per test).
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../../../.." && pwd)"
 ANVIL="$REPO_ROOT/bin/anvil"
 FEATURES_DIR="$REPO_ROOT/work/features"
+export FEATURES_DIR
 
 pass=0
 fail=0
 total=0
 
+# Source anvil functions once (cmd_lint uses return, not exit)
+ANVIL_SOURCED=1 . "$ANVIL"
+
+# run_lint <args...> — calls cmd_lint directly, captures stdout, stderr, exit code
+# Sets: _stdout, _stderr, _exit
+run_lint() {
+  _stderr_file="$(mktemp)"
+  set +e
+  _stdout="$(cmd_lint "$@" 2>"$_stderr_file")"
+  _exit=$?
+  set -e
+  _stderr="$(cat "$_stderr_file")"
+  rm -f "$_stderr_file"
+}
+
+# --- Assertion helpers ---
 assert_eq() {
   total=$((total + 1))
   label="$1"; expected="$2"; actual="$3"
@@ -21,22 +38,6 @@ assert_eq() {
     echo "  FAIL: $label"
     echo "    expected: $(echo "$expected" | head -3)"
     echo "    actual:   $(echo "$actual" | head -3)"
-    fail=$((fail + 1))
-  fi
-}
-
-assert_exit_code() {
-  total=$((total + 1))
-  label="$1"; expected_code="$2"; shift 2
-  set +e
-  "$@" >/dev/null 2>/dev/null
-  actual_code=$?
-  set -e
-  if [ "$actual_code" -eq "$expected_code" ]; then
-    echo "  PASS: $label"
-    pass=$((pass + 1))
-  else
-    echo "  FAIL: $label (expected exit $expected_code, got $actual_code)"
     fail=$((fail + 1))
   fi
 }
@@ -67,23 +68,6 @@ assert_not_contains() {
   fi
 }
 
-assert_line_count() {
-  total=$((total + 1))
-  label="$1"; expected="$2"; actual="$3"
-  if [ -z "$actual" ]; then
-    count=0
-  else
-    count="$(echo "$actual" | wc -l | tr -d ' ')"
-  fi
-  if [ "$count" -eq "$expected" ]; then
-    echo "  PASS: $label"
-    pass=$((pass + 1))
-  else
-    echo "  FAIL: $label (expected $expected lines, got $count)"
-    fail=$((fail + 1))
-  fi
-}
-
 assert_match() {
   total=$((total + 1))
   label="$1"; regex="$2"; actual="$3"
@@ -98,21 +82,14 @@ assert_match() {
   fi
 }
 
-# --- Setup: create temp test fixtures ---
-TMPDIR_TEST=""
+# ============================================================
+# BATCHED FIXTURE SETUP — create ALL test fixtures once
+# ============================================================
+PFX="_tl$$"  # short unique prefix for this run
 
-setup_fixture() {
-  TMPDIR_TEST="$(mktemp -d "$FEATURES_DIR/_test_lint_XXXXXX")"
-}
-
-teardown_fixture() {
-  [ -d "$TMPDIR_TEST" ] && rm -rf "$TMPDIR_TEST"
-}
-
-# Create a minimal valid feature with all phases and PENDING gates
+# Helper: create a minimal valid feature with all phases and PENDING gates
 create_valid_feature() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
+  fid="$1"; fdir="$FEATURES_DIR/$fid"
   mkdir -p "$fdir"
   for phase in 0-define 1-spec 2-verify 3-build 4-ship; do
     mkdir -p "$fdir/$phase"
@@ -145,45 +122,27 @@ gates:
 STATEEOF
 }
 
-# Create a feature missing state.yaml
-create_no_state_feature() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  mkdir -p "$fdir/0-define"
-}
+echo "--- Setting up fixtures ---"
 
-# Create a feature with a specific gate issue
-create_feature_bad_status() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Set 0-define gate to invalid status
-  sed -i 's/Status: PENDING/Status: BANANA/' "$fdir/0-define/gate.md"
-}
+# FIX_clean: valid feature (no lint issues)
+create_valid_feature "${PFX}_clean"
 
-create_feature_pass_no_rationale() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Set 0-define to PASS with empty rationale
-  sed -i 's/Status: PENDING/Status: PASS/' "$fdir/0-define/gate.md"
-  sed -i 's/- \[ \]/- [x]/' "$fdir/0-define/gate.md"
-}
+# FIX_badstat: feature with invalid status
+create_valid_feature "${PFX}_badstat"
+sed -i 's/Status: PENDING/Status: BANANA/' "$FEATURES_DIR/${PFX}_badstat/0-define/gate.md"
 
-create_feature_bad_checkbox() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Add a malformed checkbox
-  sed -i 's/- \[ \] Placeholder/- [X] Placeholder\n- [√] Bad checkbox/' "$fdir/0-define/gate.md"
-}
+# FIX_passnorat: PASS with empty rationale
+create_valid_feature "${PFX}_passnorat"
+sed -i 's/Status: PENDING/Status: PASS/' "$FEATURES_DIR/${PFX}_passnorat/0-define/gate.md"
+sed -i 's/- \[ \]/- [x]/' "$FEATURES_DIR/${PFX}_passnorat/0-define/gate.md"
 
-create_feature_no_frontmatter() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Remove frontmatter from 0-define gate
-  cat > "$fdir/0-define/gate.md" <<'GATEOF'
+# FIX_badcb: malformed checkbox
+create_valid_feature "${PFX}_badcb"
+sed -i 's/- \[ \] Placeholder/- [X] Placeholder\n- [√] Bad checkbox/' "$FEATURES_DIR/${PFX}_badcb/0-define/gate.md"
+
+# FIX_nofm: missing frontmatter
+create_valid_feature "${PFX}_nofm"
+cat > "$FEATURES_DIR/${PFX}_nofm/0-define/gate.md" <<'GATEOF'
 # Gate: Define (no frontmatter)
 
 - [ ] Placeholder
@@ -191,22 +150,14 @@ create_feature_no_frontmatter() {
 Status: PENDING
 Rationale:
 GATEOF
-}
 
-create_feature_missing_phase_dir() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Remove 3-build directory entirely
-  rm -rf "$fdir/3-build"
-}
+# FIX_missphase: missing phase dir (3-build removed)
+create_valid_feature "${PFX}_missphase"
+rm -rf "$FEATURES_DIR/${PFX}_missphase/3-build"
 
-create_feature_verify_pass_no_falsification() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Set 2-verify gate to PASS with rationale but no falsification
-  cat > "$fdir/2-verify/gate.md" <<'GATEOF'
+# FIX_verifynofals: verify PASS without Tried/Observed
+create_valid_feature "${PFX}_verifynofals"
+cat > "$FEATURES_DIR/${PFX}_verifynofals/2-verify/gate.md" <<'GATEOF'
 ---
 phase: 2-verify
 needs: []
@@ -221,22 +172,14 @@ Rationale:
 Tests in `evidence/` are all RED (0 of 5 passing)
 
 GATEOF
-}
 
-create_feature_needs_broken() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Set needs to a non-existent file
-  sed -i 's|needs: \[\]|needs: [../0-define/nonexistent.md]|' "$fdir/1-spec/gate.md"
-}
+# FIX_badneeds: unresolvable needs path
+create_valid_feature "${PFX}_badneeds"
+sed -i 's|needs: \[\]|needs: [../0-define/nonexistent.md]|' "$FEATURES_DIR/${PFX}_badneeds/1-spec/gate.md"
 
-create_feature_produces_pass_missing() {
-  fid="$1"
-  fdir="$FEATURES_DIR/$fid"
-  create_valid_feature "$fid"
-  # Set 0-define to PASS with produces referencing a missing file
-  cat > "$fdir/0-define/gate.md" <<'GATEOF'
+# FIX_badprod: produces path missing when PASS
+create_valid_feature "${PFX}_badprod"
+cat > "$FEATURES_DIR/${PFX}_badprod/0-define/gate.md" <<'GATEOF'
 ---
 phase: 0-define
 needs: []
@@ -253,277 +196,191 @@ See `brief.md` for the feature brief.
 Falsification:
 - Tried: checked brief.md exists -> Observed: file present
 GATEOF
-  # Do NOT create brief.md — so produces path is missing
-}
+
+# FIX_nostate: directory without state.yaml (for warning/skip tests)
+mkdir -p "$FEATURES_DIR/${PFX}_nostate/0-define"
+
+# FIX_nostate2: specific-ID lint on missing state.yaml
+create_valid_feature "${PFX}_nostate2"
+rm "$FEATURES_DIR/${PFX}_nostate2/state.yaml"
+
+echo "--- Fixtures ready ---"
+echo ""
 
 # ============================================================
 echo "=== BR-1: anvil lint <id> validates a single feature ==="
-output="$(bash "$ANVIL" lint F-2026-02-lint 2>&1 || true)"
-# Should not be rejected as unknown command
-assert_not_contains "BR-1: lint is a recognized command" "Usage:" "$output"
+run_lint "${PFX}_clean"
+assert_not_contains "BR-1: lint is a recognized command" "Usage:" "$_stdout$_stderr"
 
 # ============================================================
 echo ""
 echo "=== BR-2: anvil lint (no args) validates all features ==="
-output="$(bash "$ANVIL" lint 2>&1 || true)"
-assert_not_contains "BR-2: lint with no args is accepted" "Usage:" "$output"
+run_lint
+assert_not_contains "BR-2: lint with no args is accepted" "Usage:" "$_stdout$_stderr"
 
 # ============================================================
 echo ""
 echo "=== BR-3: exit code 0 if no issues, 1 if issues ==="
-# Create a clean valid feature
-fid="_test_lint_clean_$$"
-create_valid_feature "$fid"
-assert_exit_code "BR-3a: clean feature exits 0" 0 bash "$ANVIL" lint "$fid"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_clean"
+assert_eq "BR-3a: clean feature exits 0" "0" "$_exit"
 
-# Create a feature with a bad status => should have issues => exit 1
-fid="_test_lint_bad_$$"
-create_feature_bad_status "$fid"
-assert_exit_code "BR-3b: feature with issues exits 1" 1 bash "$ANVIL" lint "$fid"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_badstat"
+assert_eq "BR-3b: feature with issues exits 1" "1" "$_exit"
 
 # ============================================================
 echo ""
 echo "=== BR-4: output format is '<feature-id> <phase> <rule-id> <message>' ==="
-fid="_test_lint_fmt_$$"
-create_feature_bad_status "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-if [ -n "$output" ]; then
-  # Every line should have at least 4 space-separated tokens
-  bad_lines="$(echo "$output" | awk 'NF < 4 { print }' || true)"
+run_lint "${PFX}_badstat"
+if [ -n "$_stdout" ]; then
+  bad_lines="$(echo "$_stdout" | awk 'NF < 4 { print }' || true)"
   assert_eq "BR-4a: all issue lines have >=4 tokens" "" "$bad_lines"
-  # First token should be the feature ID
-  first_token="$(echo "$output" | head -1 | awk '{print $1}')"
-  assert_eq "BR-4b: first token is feature id" "$fid" "$first_token"
-  # Third token should match rule-id pattern
-  assert_match "BR-4c: third token is a rule-id" "(GATE|TMPL|XREF)-[A-Z]+" "$output"
+  first_token="$(echo "$_stdout" | head -1 | awk '{print $1}')"
+  assert_eq "BR-4b: first token is feature id" "${PFX}_badstat" "$first_token"
+  assert_match "BR-4c: third token is a rule-id" "(GATE|TMPL|XREF)-[A-Z]+" "$_stdout"
 else
   echo "  FAIL: BR-4: no output from lint on bad feature"
   fail=$((fail + 1))
   total=$((total + 1))
 fi
-rm -rf "$FEATURES_DIR/$fid"
 
 # ============================================================
 echo ""
 echo "=== BR-5: no output when all checks pass (silent clean run) ==="
-fid="_test_lint_silent_$$"
-create_valid_feature "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_eq "BR-5: clean feature produces no stdout" "" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_clean"
+assert_eq "BR-5: clean feature produces no stdout" "" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-6: warnings for unreadable features go to stderr ==="
-fid="_test_lint_nostate_$$"
-create_no_state_feature "$fid"
-stderr_out="$(bash "$ANVIL" lint 2>&1 1>/dev/null || true)"
-stdout_out="$(bash "$ANVIL" lint 2>/dev/null || true)"
-assert_contains "BR-6a: warning on stderr" "warning" "$stderr_out"
-assert_not_contains "BR-6b: no warning on stdout" "warning" "$stdout_out"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint
+assert_contains "BR-6a: warning on stderr" "warning" "$_stderr"
+assert_not_contains "BR-6b: no warning on stdout" "warning" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-7: GATE-STATUS — invalid status line is flagged ==="
-fid="_test_lint_gs_$$"
-create_feature_bad_status "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-7: GATE-STATUS issue reported" "GATE-STATUS" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_badstat"
+assert_contains "BR-7: GATE-STATUS issue reported" "GATE-STATUS" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-8: GATE-RATIONALE — PASS with empty rationale is flagged ==="
-fid="_test_lint_gr_$$"
-create_feature_pass_no_rationale "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-8: GATE-RATIONALE issue reported" "GATE-RATIONALE" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_passnorat"
+assert_contains "BR-8: GATE-RATIONALE issue reported" "GATE-RATIONALE" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-9: GATE-CHECKLIST — malformed checkbox flagged ==="
-fid="_test_lint_gc_$$"
-create_feature_bad_checkbox "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-9: GATE-CHECKLIST issue reported" "GATE-CHECKLIST" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_badcb"
+assert_contains "BR-9: GATE-CHECKLIST issue reported" "GATE-CHECKLIST" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-10: GATE-FRONTMATTER — missing frontmatter flagged ==="
-fid="_test_lint_gf_$$"
-create_feature_no_frontmatter "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-10: GATE-FRONTMATTER issue reported" "GATE-FRONTMATTER" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_nofm"
+assert_contains "BR-10: GATE-FRONTMATTER issue reported" "GATE-FRONTMATTER" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-11: GATE-FALSIFICATION — verify/ship PASS without Tried/Observed ==="
-fid="_test_lint_gfals_$$"
-create_feature_verify_pass_no_falsification "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-11: GATE-FALSIFICATION issue reported" "GATE-FALSIFICATION" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_verifynofals"
+assert_contains "BR-11: GATE-FALSIFICATION issue reported" "GATE-FALSIFICATION" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-12: TMPL-PHASE — missing phase dir or gate.md flagged ==="
-fid="_test_lint_tp_$$"
-create_feature_missing_phase_dir "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-12: TMPL-PHASE issue reported" "TMPL-PHASE" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_missphase"
+assert_contains "BR-12: TMPL-PHASE issue reported" "TMPL-PHASE" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-13: TMPL-STATE — missing state.yaml flagged ==="
-# Create feature with state.yaml, then remove it for lint of that specific ID
-fid="_test_lint_ts_$$"
-create_valid_feature "$fid"
-rm "$FEATURES_DIR/$fid/state.yaml"
-# When linting a specific ID with no state.yaml, it should either warn/error
-output="$(bash "$ANVIL" lint "$fid" 2>&1 || true)"
-assert_match "BR-13: TMPL-STATE or error for missing state.yaml" "(TMPL-STATE|warning|ERROR)" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_nostate2"
+assert_match "BR-13: TMPL-STATE or error for missing state.yaml" "(TMPL-STATE|warning|ERROR)" "$_stdout$_stderr"
 
 # ============================================================
 echo ""
 echo "=== BR-14: XREF-NEEDS — unresolvable needs path flagged ==="
-fid="_test_lint_xn_$$"
-create_feature_needs_broken "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-14: XREF-NEEDS issue reported" "XREF-NEEDS" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_badneeds"
+assert_contains "BR-14: XREF-NEEDS issue reported" "XREF-NEEDS" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-15: XREF-PRODUCES — produces missing when PASS, flagged ==="
-fid="_test_lint_xp_$$"
-create_feature_produces_pass_missing "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-assert_contains "BR-15: XREF-PRODUCES issue reported" "XREF-PRODUCES" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_badprod"
+assert_contains "BR-15: XREF-PRODUCES issue reported" "XREF-PRODUCES" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== BR-16: lint does NOT validate checklist-vs-status, staleness, dirty, anchors ==="
-# A PENDING gate with unchecked items should NOT produce issues from lint
-# (that's anvil check's job)
-fid="_test_lint_nocheck_$$"
-create_valid_feature "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-# Should have zero issues — PENDING gates with unchecked items are fine for lint
-assert_eq "BR-16: lint ignores check-domain concerns" "" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_clean"
+assert_eq "BR-16: lint ignores check-domain concerns" "" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== IT-1: anvil lint must NOT write to any file ==="
-fid="_test_lint_ro_$$"
-create_valid_feature "$fid"
-before_state="$(cat "$FEATURES_DIR/$fid/state.yaml")"
-# Snapshot all file mtimes
-before_times="$(find "$FEATURES_DIR/$fid" -type f -exec ls -l --time-style=+%s {} + 2>/dev/null || find "$FEATURES_DIR/$fid" -type f -exec stat -f '%m %N' {} + 2>/dev/null || true)"
-bash "$ANVIL" lint "$fid" >/dev/null 2>&1 || true
-after_state="$(cat "$FEATURES_DIR/$fid/state.yaml")"
-after_times="$(find "$FEATURES_DIR/$fid" -type f -exec ls -l --time-style=+%s {} + 2>/dev/null || find "$FEATURES_DIR/$fid" -type f -exec stat -f '%m %N' {} + 2>/dev/null || true)"
+before_state="$(cat "$FEATURES_DIR/${PFX}_clean/state.yaml")"
+before_times="$(find "$FEATURES_DIR/${PFX}_clean" -type f -exec ls -l --time-style=+%s {} + 2>/dev/null || find "$FEATURES_DIR/${PFX}_clean" -type f -exec stat -f '%m %N' {} + 2>/dev/null || true)"
+run_lint "${PFX}_clean"
+after_state="$(cat "$FEATURES_DIR/${PFX}_clean/state.yaml")"
+after_times="$(find "$FEATURES_DIR/${PFX}_clean" -type f -exec ls -l --time-style=+%s {} + 2>/dev/null || find "$FEATURES_DIR/${PFX}_clean" -type f -exec stat -f '%m %N' {} + 2>/dev/null || true)"
 assert_eq "IT-1a: state.yaml unchanged" "$before_state" "$after_state"
 assert_eq "IT-1b: no file mtimes changed" "$before_times" "$after_times"
-rm -rf "$FEATURES_DIR/$fid"
 
 # ============================================================
 echo ""
 echo "=== IT-2: anvil lint must NOT call update_state ==="
-# If update_state were called, state.yaml would change. We already checked IT-1.
-# Additionally verify that a feature with issues still doesn't modify state.
-fid="_test_lint_rous_$$"
-create_feature_bad_status "$fid"
-before="$(cat "$FEATURES_DIR/$fid/state.yaml")"
-bash "$ANVIL" lint "$fid" >/dev/null 2>&1 || true
-after="$(cat "$FEATURES_DIR/$fid/state.yaml")"
+before="$(cat "$FEATURES_DIR/${PFX}_badstat/state.yaml")"
+run_lint "${PFX}_badstat"
+after="$(cat "$FEATURES_DIR/${PFX}_badstat/state.yaml")"
 assert_eq "IT-2: state.yaml not modified even with lint issues" "$before" "$after"
-rm -rf "$FEATURES_DIR/$fid"
 
 # ============================================================
 echo ""
 echo "=== INV-1: output line count equals total number of issues ==="
-fid="_test_lint_inv1_$$"
-create_feature_bad_status "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-if [ -n "$output" ]; then
-  line_count="$(echo "$output" | wc -l | tr -d ' ')"
-  # Each line should be one issue — no blank lines, no headers
-  blank_lines="$(echo "$output" | grep -c '^$' || true)"
+run_lint "${PFX}_badstat"
+if [ -n "$_stdout" ]; then
+  blank_lines="$(echo "$_stdout" | grep -c '^$' || true)"
   assert_eq "INV-1: no blank lines in output (every line is an issue)" "0" "$blank_lines"
 else
   echo "  FAIL: INV-1: expected issues but got no output"
   fail=$((fail + 1))
   total=$((total + 1))
 fi
-rm -rf "$FEATURES_DIR/$fid"
 
 # ============================================================
 echo ""
 echo "=== INV-2: exit 0 iff stdout line count is 0 ==="
-# Clean feature: exit 0, no stdout
-fid="_test_lint_inv2a_$$"
-create_valid_feature "$fid"
-set +e
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null)"
-code=$?
-set -e
-assert_eq "INV-2a: clean feature exit 0" "0" "$code"
-assert_eq "INV-2a: clean feature no stdout" "" "$output"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint "${PFX}_clean"
+assert_eq "INV-2a: clean feature exit 0" "0" "$_exit"
+assert_eq "INV-2a: clean feature no stdout" "" "$_stdout"
 
-# Broken feature: exit 1, has stdout
-fid="_test_lint_inv2b_$$"
-create_feature_bad_status "$fid"
-set +e
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null)"
-code=$?
-set -e
-assert_eq "INV-2b: broken feature exit 1" "1" "$code"
-# Should have at least one line of output
-if [ -n "$output" ]; then
+run_lint "${PFX}_badstat"
+assert_eq "INV-2b: broken feature exit 1" "1" "$_exit"
+total=$((total + 1))
+if [ -n "$_stdout" ]; then
   echo "  PASS: INV-2b: broken feature has stdout"
   pass=$((pass + 1))
 else
   echo "  FAIL: INV-2b: broken feature should have stdout"
   fail=$((fail + 1))
 fi
-total=$((total + 1))
-rm -rf "$FEATURES_DIR/$fid"
 
 # ============================================================
 echo ""
 echo "=== INV-3: no stdout for warnings/errors — warnings go to stderr ==="
-fid="_test_lint_inv3_$$"
-create_no_state_feature "$fid"
-stdout_out="$(bash "$ANVIL" lint 2>/dev/null || true)"
-# The warning about no state.yaml should NOT appear on stdout
-assert_not_contains "INV-3: no warning text on stdout" "$fid" "$stdout_out"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint
+assert_not_contains "INV-3: no warning text on stdout" "${PFX}_nostate" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== INV-4: freshly scaffolded feature produces zero lint issues ==="
-fid="_test_lint_inv4_$$"
-# Scaffold with anvil init
+fid="${PFX}_scaff"
 bash "$ANVIL" init "$fid" >/dev/null 2>&1 || true
 if [ -d "$FEATURES_DIR/$fid" ]; then
-  set +e
-  output="$(bash "$ANVIL" lint "$fid" 2>/dev/null)"
-  code=$?
-  set -e
-  assert_eq "INV-4a: scaffolded feature has no lint issues (exit 0)" "0" "$code"
-  assert_eq "INV-4b: scaffolded feature produces no stdout" "" "$output"
-  rm -rf "$FEATURES_DIR/$fid"
+  run_lint "$fid"
+  assert_eq "INV-4a: scaffolded feature has no lint issues (exit 0)" "0" "$_exit"
+  assert_eq "INV-4b: scaffolded feature produces no stdout" "" "$_stdout"
 else
   echo "  FAIL: INV-4: could not scaffold test feature"
   fail=$((fail + 1))
@@ -533,70 +390,53 @@ fi
 # ============================================================
 echo ""
 echo "=== INV-5: every issue line has >=4 tokens, third matches (GATE|TMPL|XREF)-[A-Z]+ ==="
-fid="_test_lint_inv5_$$"
-create_feature_bad_status "$fid"
-output="$(bash "$ANVIL" lint "$fid" 2>/dev/null || true)"
-if [ -n "$output" ]; then
-  # Check all lines have >=4 tokens
-  bad_token_lines="$(echo "$output" | awk 'NF < 4' || true)"
+run_lint "${PFX}_badstat"
+if [ -n "$_stdout" ]; then
+  bad_token_lines="$(echo "$_stdout" | awk 'NF < 4' || true)"
   assert_eq "INV-5a: all lines have >=4 tokens" "" "$bad_token_lines"
-  # Check third token matches pattern
-  bad_rule_lines="$(echo "$output" | awk '{if ($3 !~ /^(GATE|TMPL|XREF)-[A-Z]+$/) print}' || true)"
+  bad_rule_lines="$(echo "$_stdout" | awk '{if ($3 !~ /^(GATE|TMPL|XREF)-[A-Z]+$/) print}' || true)"
   assert_eq "INV-5b: all rule-ids match pattern" "" "$bad_rule_lines"
 else
   echo "  FAIL: INV-5: expected output from bad feature"
   fail=$((fail + 1))
   total=$((total + 1))
 fi
-rm -rf "$FEATURES_DIR/$fid"
 
 # ============================================================
 echo ""
 echo "=== ERR-1: feature dir with no state.yaml -> skip, warn on stderr ==="
-fid="_test_lint_err1_$$"
-create_no_state_feature "$fid"
-stderr_out="$(bash "$ANVIL" lint 2>&1 1>/dev/null || true)"
-assert_contains "ERR-1: stderr warns about missing state.yaml" "$fid" "$stderr_out"
-rm -rf "$FEATURES_DIR/$fid"
+run_lint
+assert_contains "ERR-1: stderr warns about missing state.yaml" "${PFX}_nostate" "$_stderr"
 
 # ============================================================
 echo ""
 echo "=== ERR-2: feature ID given but dir does not exist -> error on stderr, exit 1 ==="
-set +e
-output="$(bash "$ANVIL" lint _nonexistent_feature_$$ 2>&1)"
-code=$?
-set -e
-assert_eq "ERR-2a: exit 1 for missing feature" "1" "$code"
-stderr_out="$(bash "$ANVIL" lint _nonexistent_feature_$$ 2>&1 1>/dev/null || true)"
-assert_match "ERR-2b: error message on stderr" "(ERROR|error|not found)" "$stderr_out"
+run_lint "_nonexistent_feature_$$"
+assert_eq "ERR-2a: exit 1 for missing feature" "1" "$_exit"
+assert_match "ERR-2b: error message on stderr" "(ERROR|error|not found)" "$_stderr"
 
 # ============================================================
 echo ""
 echo "=== ERR-3: FEATURES_DIR does not exist -> exit 0, no output ==="
-# Temporarily set features dir to a nonexistent path by testing lint behavior
-# We can test this by checking current behavior: if FEATURES_DIR is missing, exit 0
-# Since we can't easily override env in the script, we test that the command
-# handles an empty features dir gracefully
-set +e
-output="$(FEATURES_DIR=/tmp/_anvil_nonexistent_$$ bash "$ANVIL" lint 2>/dev/null)"
-code=$?
-set -e
-assert_eq "ERR-3a: exit 0 when features dir missing" "0" "$code"
-assert_eq "ERR-3b: no output when features dir missing" "" "$output"
+_saved_fd="$FEATURES_DIR"
+FEATURES_DIR="/tmp/_anvil_nonexistent_$$"
+run_lint
+FEATURES_DIR="$_saved_fd"
+assert_eq "ERR-3a: exit 0 when features dir missing" "0" "$_exit"
+assert_eq "ERR-3b: no output when features dir missing" "" "$_stdout"
 
 # ============================================================
 echo ""
 echo "=== HS-1: directory traversal prevention ==="
-set +e
-output="$(bash "$ANVIL" lint "../../etc/passwd" 2>&1)"
-code=$?
-set -e
-# Should reject the path, not process it
-assert_not_contains "HS-1: no processing of traversal paths" "GATE-" "$output"
+run_lint "../../etc/passwd"
+assert_not_contains "HS-1: no processing of traversal paths" "GATE-" "$_stdout"
 
 # ============================================================
-# Final cleanup: remove any stale test fixtures
-for d in "$FEATURES_DIR"/_test_lint_*; do
+# BATCHED FIXTURE CLEANUP
+# ============================================================
+echo ""
+echo "--- Cleaning up fixtures ---"
+for d in "$FEATURES_DIR"/${PFX}_*; do
   [ -d "$d" ] && rm -rf "$d"
 done
 


### PR DESCRIPTION
## Summary
- Fix `validate_gate` rationale parser to accept both inline (`Rationale: text`) and next-line formats — makes it idiot-proof
- Add `ANVIL_SOURCED` guard so tests can source `bin/anvil` and call functions directly without fork overhead
- Change `cmd_lint`/`cmd_list` to use `return` instead of `exit` for source-ability
- Rewrite both test suites with batched fixtures and sourced functions
- Add LLM consumer convention to `CLAUDE.md`

## Test plan
- [x] All 39 lint tests pass (run-tests.sh)
- [x] All 8 dashboard tests pass (run-tests.sh)
- [x] `anvil lint` and `anvil list` work correctly via CLI
- [x] Both inline and next-line rationale formats accepted by `anvil advance`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)